### PR TITLE
feat: validar tickers antes de salvar e limpar inválidos na inicialização

### DIFF
--- a/favorites.json
+++ b/favorites.json
@@ -1,7 +1,7 @@
 [
   "BBSE3",
-  "123123",
   "XPLG11",
   "GARE11",
-  "MXRF11"
+  "MXRF11",
+  "DXCO3"
 ]


### PR DESCRIPTION
- Adiciona função `isValidTicker` para checar existência de dados antes de incluir nos favoritos
- Impede que tickers inválidos sejam gravados em `favorites.json`
- Ao iniciar, filtra e remove automaticamente quaisquer tickers inválidos já salvos