### PR TITLE
feat: adicionar autocomplete de ativos por nome e ticker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,32 +1,40 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy"
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';">
-    <title>FiiWidget</title>
-    <link rel="stylesheet" href="style.css">
+  <title>FiiWidget</title>
+  <link rel="stylesheet" href="style.css">
 </head>
-
 <body>
-    <div id="wrapper">
-        <div id="drag-region"></div>
-        <div id="controls">
-            <input type="text" id="tickerInput" placeholder="Digite o ticker" />
-            <button id="addButton">Adicionar</button>
-        </div>
-        <div id="chartRangeControls">
-            <button data-days="5" class="active">5d</button>
-            <button data-days="10">10d</button>
-            <button data-days="15">15d</button>
-            <button data-days="30">30d</button>
-            <button data-days="365">1a</button>
-            <button data-days="1825">5a</button>
-        </div>
-        <div id="container"></div>
-    </div>
-    <script src="renderer.js"></script>
-</body>
+  <div id="wrapper">
+    <div id="drag-region"></div>
 
+    <div id="header">
+      <div id="controls">
+        <input 
+          type="text" 
+          id="tickerInput" 
+          placeholder="Digite nome ou código" 
+          list="assetOptions"
+        />
+        <datalist id="assetOptions"></datalist>
+        <button id="addButton">Adicionar</button>
+      </div>
+
+      <div id="chartRangeControls">
+        <button data-days="5"    class="active">5d</button>
+        <button data-days="10">10d</button>
+        <button data-days="15">15d</button>
+        <button data-days="30">30d</button>
+        <button data-days="365">1a</button>
+        <button data-days="1825">5a</button>
+      </div>
+    </div>
+
+    <div id="container"></div>
+  </div>
+  <script src="renderer.js"></script>
+</body>
 </html>

--- a/main.js
+++ b/main.js
@@ -56,4 +56,15 @@ ipcMain.handle('fetch-history', async (_, ticker, days = 5) => {
   }
 });
 
+ipcMain.handle('search-assets', async (_, query) => {
+  if (!query) return [];
+  try {
+    const result = await yahooFinance.search(query, { quotesCount: 10, newsCount: 0 });
+    return result.quotes || [];
+  } catch (err) {
+    console.warn('Erro em search-assets:', err.message);
+    return [];
+  }
+});
+
 app.whenReady().then(createWindow);

--- a/preload.js
+++ b/preload.js
@@ -1,8 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electron', {
-  fetchStock: (ticker) => ipcRenderer.invoke('fetch-stock', ticker),
+  fetchStock: ticker => ipcRenderer.invoke('fetch-stock', ticker),
   fetchHistory: (ticker, days) => ipcRenderer.invoke('fetch-history', ticker, days),
   getFavorites: () => ipcRenderer.invoke('get-favorites'),
-  saveFavorites: (favorites) => ipcRenderer.invoke('save-favorites', favorites),
+  saveFavorites: favs => ipcRenderer.invoke('save-favorites', favs),
+  searchAssets:  query => ipcRenderer.invoke('search-assets', query),
 });

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* Reset e layout principal */
+
 html,
 body {
     margin: 0;
@@ -14,7 +14,7 @@ body {
 
 #drag-region {
     height: 30px;
-    /* ou o valor que quiser */
+   
     width: 100%;
     -webkit-app-region: drag;
 }
@@ -25,7 +25,7 @@ input {
 }
 
 
-/* Envolve tudo */
+
 #wrapper {
     display: flex;
     flex-direction: column;
@@ -36,7 +36,7 @@ input {
     box-sizing: border-box;
 }
 
-/* Controles no topo */
+
 #controls {
     display: flex;
     flex-direction: column;
@@ -46,7 +46,7 @@ input {
     padding-bottom: 10px;
 }
 
-/* Input e botão */
+
 #tickerInput {
     width: 100%;
     padding: 6px;
@@ -68,7 +68,7 @@ input {
     background-color: #45a049;
 }
 
-/* Container com os cards (com scroll bonitinho) */
+
 #container {
     flex-grow: 1;
     overflow-y: auto;
@@ -98,7 +98,7 @@ input {
     background: rgba(255, 255, 255, 0.5);
 }
 
-/* Cartões */
+
 .card {
     position: relative;
     padding: 10px;
@@ -112,7 +112,7 @@ input {
     text-align: center;
 }
 
-/* Animações de fade */
+
 .fade-in {
     opacity: 0;
     transform: scale(0.9);
@@ -137,7 +137,7 @@ input {
     }
 }
 
-/* Botão de remover */
+
 .remove-button {
     background: none;
     border: none;
@@ -149,7 +149,7 @@ input {
     cursor: pointer;
 }
 
-/* Cores para variação */
+
 .change.up {
     color: #4caf50;
 }
@@ -168,14 +168,14 @@ input {
     margin-bottom: 12px;  
     display: flex;
     flex-wrap: wrap;
-    /* permite quebrar em mais de uma linha */
+   
     gap: 4px;
     justify-content: center;
 }
 
 #chartRangeControls button {
     flex: 1 1 48px;
-    /* tenta ocupar equally, mas não fica menor que 48px */
+   
     padding: 4px 6px;
     font-size: 0.85rem;
     border: none;


### PR DESCRIPTION
- Cria handler IPC `search-assets` em `main.js` para buscar sugestões no Yahoo Finance
- Exponibiliza `searchAssets` em `preload.js`
- Atualiza `index.html`, incluindo `<datalist id="assetOptions">` e atribuindo `list="assetOptions"` ao input
- Implementa listener em `renderer.js` que consome `searchAssets` e preenche o datalist com opções (símbolo + nome)
- Mantém validação de ticker antes de salvar, agora suportando seleção via autocomplete